### PR TITLE
Proper placement of clear button

### DIFF
--- a/src/UiAutocomplete.vue
+++ b/src/UiAutocomplete.vue
@@ -394,7 +394,6 @@ export default {
     font-size: 18px;
     position: absolute;
     right: 0;
-    top: 6px;
     color: $input-clear-button-color;
     cursor: default;
 


### PR DESCRIPTION
Simply removing the top property should be able to fix the position.

Seems to be missing completely in Firefox (Mac)