### PR TITLE
make the ui-select can be easily selected in the editing page

### DIFF
--- a/src-docs/components/UiSelectDocs.vue
+++ b/src-docs/components/UiSelectDocs.vue
@@ -52,10 +52,10 @@
 
             <h4>Multiple with defaults selection</h4>
 
-            <!--<ui-select
+            <ui-select
                 name="color" label="Favourite colors" partial="ui-select-image" show-search multiple
                 placeholder="Select some colors" :options="colors" :default="[colors[0], colors[3]]"
-            ></ui-select>-->
+            ></ui-select>
 
             <h4>With validation</h4>
 
@@ -99,10 +99,10 @@
 
             <h4>Disabled with selection</h4>
 
-            <!--<ui-select
+            <ui-select
                 name="color" label="Favourite color" :options="colors" placeholder="Select a color"
                 :default="colors[2]" disabled
-            ></ui-select>-->
+            ></ui-select>
 
             <ui-button @click="resetSelects">Reset selects</ui-button>
         </div>

--- a/src-docs/components/UiSelectDocs.vue
+++ b/src-docs/components/UiSelectDocs.vue
@@ -19,7 +19,7 @@
 
             <ui-select
                 name="color" label="Favourite color" :options="colors" placeholder="Select a color"
-                :default="colors[0]"
+                :default="colorSelect"
             ></ui-select>
 
             <h4>With images</h4>
@@ -52,10 +52,10 @@
 
             <h4>Multiple with defaults selection</h4>
 
-            <ui-select
+            <!--<ui-select
                 name="color" label="Favourite colors" partial="ui-select-image" show-search multiple
                 placeholder="Select some colors" :options="colors" :default="[colors[0], colors[3]]"
-            ></ui-select>
+            ></ui-select>-->
 
             <h4>With validation</h4>
 
@@ -99,10 +99,10 @@
 
             <h4>Disabled with selection</h4>
 
-            <ui-select
+            <!--<ui-select
                 name="color" label="Favourite color" :options="colors" placeholder="Select a color"
                 :default="colors[2]" disabled
-            ></ui-select>
+            ></ui-select>-->
 
             <ui-button @click="resetSelects">Reset selects</ui-button>
         </div>
@@ -659,6 +659,11 @@ export default {
     data() {
         return {
             colors,
+            colorSelect: {
+                text: 'Pink',
+                image: 'https://placehold.it/64/ffc0cb/ffc0cb',
+                value: 'pink'
+            },
             dynamicSelect: {
                 value: null,
                 options: [],

--- a/src/UiSelect.vue
+++ b/src/UiSelect.vue
@@ -411,7 +411,7 @@ export default {
 
                 for (let i = 0; i < this.options.length; i++) {
                     for (let j = 0; j < defaults.length; j++) {
-                        if (this.options[i] === defaults[j]) {
+                        if (this.options[i].value === defaults[j].value) {
                             this.select(this.options[i], i, false);
                             break;
                         }
@@ -422,7 +422,7 @@ export default {
             }
 
             for (let i = 0; i < this.options.length; i++) {
-                if (this.options[i] === defaults) {
+                if (this.options[i].value === defaults.value) {
                     this.select(this.options[i], i, false);
                     break;
                 }


### PR DESCRIPTION
i think using an independent object for the default props is better than using the child object of the option's array;