### PR TITLE
fix very small bug with webpack hot-reloading 

### DIFF
--- a/src/UiModal.vue
+++ b/src/UiModal.vue
@@ -173,7 +173,9 @@ export default {
             document.removeEventListener('focus', this.restrictFocus, true);
 
             if(this.lastFocussedElement)
+            {
                 this.lastFocussedElement.focus();
+            }
         }
     },
 

--- a/src/UiModal.vue
+++ b/src/UiModal.vue
@@ -172,7 +172,8 @@ export default {
 
             document.removeEventListener('focus', this.restrictFocus, true);
 
-            this.lastFocussedElement.focus();
+            if(this.lastFocussedElement)
+                this.lastFocussedElement.focus();
         }
     },
 

--- a/src/UiProgressLinear.vue
+++ b/src/UiProgressLinear.vue
@@ -31,7 +31,7 @@ export default {
         },
         color: {
             type: String,
-            default: 'color-primary', // 'primary', 'accent', 'black' or 'white'
+            default: 'primary', // 'primary', 'accent', 'black' or 'white'
             coerce(color) {
                 return 'color-' + color;
             }


### PR DESCRIPTION
Added a small check to stop webpack hot-reload to reloading full page instead of component only !

```js
[HMR] Cannot check for update (Full reload needed)
process-update.js?e13e:116 [HMR] TypeError: Cannot read property 'focus' of null
    at UiModal.tearDown (eval at <anonymous> (http://localhost:8080/app.js:720:2), <anonymous>:8096:39)
    at UiModal.eval [as tearDown] (eval at <anonymous> (http://localhost:8080/app.js:594:2), <anonymous>:216:72)
    at UiModal.beforeDestroy (eval at <anonymous> (http://localhost:8080/app.js:720:2), <anonymous>:8045:19)
    at UiModal.Vue._callHook (eval at <anonymous> (http://localhost:8080/app.js:594:2), <anonymous>:8199:21)
    at UiModal.Vue._destroy (eval at <anonymous> (http://localhost:8080/app.js:594:2), <anonymous>:8673:10)
    at UiModal.Vue.$destroy (eval at <anonymous> (http://localhost:8080/app.js:594:2), <anonymous>:9440:10)
    at VueComponent.Vue._destroy (eval at <anonymous> (http://localhost:8080/app.js:594:2), <anonymous>:8687:25)
    at VueComponent.Vue.$destroy (eval at <anonymous> (http://localhost:8080/app.js:594:2), <anonymous>:9440:10)
    at Directive.unbuild (eval at <anonymous> (http://localhost:8080/app.js:594:2), <anonymous>:5852:11)
    at Directive.View.unbuild (eval at <anonymous> (http://localhost:8080/app.js:636:2), <anonymous>:59:20)
process-update.js?e13e:128 [HMR] Reloading page```

