### PR TITLE
UiCollapsible: change offsetHeight to scrollHeight

### DIFF
--- a/src/UiCollapsible.vue
+++ b/src/UiCollapsible.vue
@@ -117,7 +117,7 @@ export default {
             var body = this.$els.body;
 
             body.style.display = 'block';
-            this.height = body.offsetHeight;
+            this.height = body.scrollHeight;
 
             if (!this.open) {
                 body.style.display = 'none';


### PR DESCRIPTION
This would resolve #97.

setHeight uses the element's offsetHeight when refreshing collapsible size. This PR changes this to `scrollHeight` which will account for overflow cases.

Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element.scrollHeight) on scrollHeight:
> The Element.scrollHeight read-only attribute is a measurement of the height of an element's content, **including content not visible on the screen due to overflow**.

--

Here's a couple pens to show the difference between the two attributes. They're identical except for the version of Keen they use. `offsetHeight` is using the original while `scrollHeight` is patched with the change from this PR.

[offsetHeight codepen](http://codepen.io/citycide/pen/WxyBYG)
The table collapsible doesn't show the full size, so the scroll bar is cut off at the bottom.
The second collapsible never resizes even after firing the refresh event.

[scrollHeight codepen](http://codepen.io/citycide/pen/ZORNrX)
The table collapsible's contents & scrollbar is fully visible and is not cut off.
The second collapsible is resized correctly after firing the refresh event.

--

Apologies about the lack of built files in the PR ( which makes this a 6-character patch heh ). 1. I run Windows :smiley: and 2. there was an issue with stylus / stylus-loader that was erroring out my builds. Seemed related / same issue as these:

https://github.com/webpack/webpack/issues/2059
https://github.com/webpack/css-loader/issues/106#issuecomment-218787297