### PR TITLE
Modify UiRippleInk to use event.target

### DIFF
--- a/src/UiRippleInk.vue
+++ b/src/UiRippleInk.vue
@@ -12,7 +12,7 @@
 import classlist from './helpers/classlist';
 
 var startRipple = function startRipple(eventType, event) {
-    var holder = event.currentTarget;
+    var holder = event.target || event.currentTarget;
 
     if (! classlist.has(holder, 'ui-ripple-ink')) {
         holder = holder.querySelector('.ui-ripple-ink');


### PR DESCRIPTION
#162 

Bug; [UiButton](https://josephuspaye.github.io/Keen-UI/#/ui-button-docs) 'With Menu':
Enable mobile emulation and touch events in Firefox or Chrome.

In Chrome, throws error but does not open: 
`docs.bundle.js:formatted:5929 Uncaught TypeError: Cannot read property 'querySelector' of undefined`
On formatted line: `if (r["default"].has(o, "ui-ripple-ink") || (o = o.querySelector(".ui-ripple-ink"))) {`

In Firefox, menu opens, after a delay ripple activates, menu closes prematurely.