### PR TITLE
[Not-working] Above/below tab body placement

### DIFF
--- a/src/UiTabs.vue
+++ b/src/UiTabs.vue
@@ -1,5 +1,9 @@
 <template>
     <div class="ui-tabs" :class="styleClasses">
+        <div v-if="placement === 'above'" class="ui-tabs-body">
+            <slot></slot>
+        </div>
+
         <div class="ui-tabs-header" :class="[backgroundColor]">
             <ul
                 class="ui-tabs-header-items" :class="[textColor, textColorActive]" role="tablist"
@@ -18,12 +22,12 @@
             </ul>
 
             <div
-                class="ui-tabs-active-tab-indicator" :class="[indicatorColor]"
+                class="ui-tabs-active-tab-indicator" :class="[indicatorColor, placement]"
                 :style="{ 'left': indicatorLeft, 'right': indicatorRight }"
             ></div>
         </div>
 
-        <div class="ui-tabs-body">
+        <div v-if="placement === 'below'" class="ui-tabs-body">
             <slot></slot>
         </div>
     </div>
@@ -66,6 +70,10 @@ export default {
             coerce(color) {
                 return 'text-color-active-' + color;
             }
+        },
+        placement: {
+            type: String,
+            default: 'below'
         },
         indicatorColor: {
             type: String,
@@ -375,7 +383,14 @@ export default {
 .ui-tabs-active-tab-indicator {
     position: absolute;
     height: 2px;
-    bottom: 0;
+
+    &.above {
+      top: 0;
+    }
+
+    &.below {
+      bottom: 0;
+    }
 
     transition: all 0.2s ease;
     box-shadow: 0 -1px 2px alpha(black, 0.05);


### PR DESCRIPTION
Hi,

I am attempting to introduce 'placement' to the UiTabs component; I would like there to exist a property which if set will place the tab body above the tabs, such as:

![Tabs below content](http://i.imgur.com/9wNsjnS.png)

I do not know enough about Vue to accomplish this, it seems, I do not wish to include the tab-body element twice like I have done, but I am unsure as to how I could reorder them. I do not wish to create a separate UiTabsBelow control unless I have to.

Any recommendations?
