### PR TITLE
[UiTabs] Fixed bug where `indicatorColor` prop wasn't applied

### DIFF
--- a/src/UiTabs.vue
+++ b/src/UiTabs.vue
@@ -109,7 +109,7 @@ export default {
                 `ui-tabs--text-color-${this.textColor}`,
                 `ui-tabs--text-color-active-${this.textColorActive}`,
                 `ui-tabs--background-color-${this.backgroundColor}`,
-                `ui-tabs--indicator-color-${this.textColorActive}`,
+                `ui-tabs--indicator-color-${this.indicatorColor}`,
                 { 'is-raised': this.raised },
                 { 'is-fullwidth': this.fullwidth }
             ];


### PR DESCRIPTION
This commit changes the computed classes to include the indicator color that was set as a prop. Until now, the `textColorActive` prop was applied.