### PR TITLE
allow string and can set "0"

### DIFF
--- a/src/UiSlider.vue
+++ b/src/UiSlider.vue
@@ -91,7 +91,7 @@ export default {
             type: Boolean,
             default: false
         },
-        markerValue: Number,
+        markerValue: [String, Number],
         disabled: {
             type: Boolean,
             default: false
@@ -138,7 +138,7 @@ export default {
         },
 
         markerText() {
-            return this.markerValue ? this.markerValue : this.value;
+            return this.markerValue === false ? this.markerValue : this.value;
         },
 
         snapPoints() {


### PR DESCRIPTION
In [document](https://github.com/JosephusPaye/Keen-UI/blob/master/docs-src/pages/UiSlider.vue#L109), `UiSlider`'s markerValue allow `String`, and this is right.
This PR resolve the problem we can't set string markerValue and set 0 or "0".