### PR TITLE
Added explicit keys for tabs

### DIFF
--- a/src/UiTabs.vue
+++ b/src/UiTabs.vue
@@ -20,6 +20,7 @@
                     @keydown.right.native="selectNextTab"
 
                     v-for="tab in tabs"
+                    :key="tab.id"
                     v-show="tab.show"
                 >
                     <render-vnodes


### PR DESCRIPTION
Last version of vue (2.2.6) required this: component lists rendered with v-for should have explicit keys. See https://vuejs.org/guide/list.html#key for more info.