### PR TITLE
Click and Change events have different order in Safari

### DIFF
--- a/src/UiCheckbox.vue
+++ b/src/UiCheckbox.vue
@@ -101,6 +101,7 @@ export default {
         },
 
         onChange(e) {
+            this.isChecked = e.target.checked;
             this.$emit('change', this.isChecked ? this.trueValue : this.falseValue, e);
         },
 


### PR DESCRIPTION
In the (mobile) Safari browsers the 'click' en 'change' events on input are in a different order. This caused the UICheckbox to function unexpectedly and the UiCheckboxGroup to not function at all.

isChecked value is now set on both input and click events to account for the different order they occur in for example Chrome and Safari.