### PR TITLE
Option for always keep extra space on UiTextbox

### DIFF
--- a/src/UiTextbox.vue
+++ b/src/UiTextbox.vue
@@ -163,6 +163,10 @@ export default {
         disabled: {
             type: Boolean,
             default: false
+        },
+        keepExtra: {
+            type: Boolean,
+            default: false
         }
     },
 
@@ -230,7 +234,7 @@ export default {
         },
 
         hasFeedback() {
-            return Boolean(this.help) || Boolean(this.error);
+            return Boolean(this.help) || Boolean(this.error) || this.keepExtra;
         },
 
         showError() {


### PR DESCRIPTION
as a former UX designer i prefer to inputs (also all other elements) stay in same position as they were during filling forms.