### PR TITLE
Fix: UISelect help slot not displaying without also setting the help prop

### DIFF
--- a/src/UiSelect.vue
+++ b/src/UiSelect.vue
@@ -279,7 +279,8 @@ export default {
         },
 
         hasFeedback() {
-            return Boolean(this.help) || Boolean(this.error) || Boolean(this.$slots.error);
+            return Boolean(this.help) || Boolean(this.error) || 
+                Boolean(this.$slots.error) || Boolean(this.$slots.help);
         },
 
         showError() {


### PR DESCRIPTION
Fixes https://github.com/JosephusPaye/Keen-UI/issues/369