### PR TITLE
Update UiSelect.vue

### DIFF
--- a/docs-src/pages/UiSelect.vue
+++ b/docs-src/pages/UiSelect.vue
@@ -174,7 +174,7 @@
                 :options="colourStrings"
                 v-model="select12o5"
             >
-                <template scope="props" slot="option">
+                <template slot-scope="props" slot="option">
                     <code>{{ props }}</code>
                 </template>
             </ui-select>


### PR DESCRIPTION
The "scope" attribute for scoped slots have been deprecated and replaced by "slot-scope" since 2.5