### PR TITLE
Fix clearQuery running on multiple select

### DIFF
--- a/src/UiSelect.vue
+++ b/src/UiSelect.vue
@@ -433,7 +433,7 @@ export default {
             });
 
             this.highlightedIndex = index;
-            this.clearQuery();
+            if (!this.multiple) this.clearQuery();
 
             if (!this.multiple && options.autoClose) {
                 this.closeDropdown();


### PR DESCRIPTION
The search query is being cleared in multiple select mode, this means if you search for a shared term and then try to click a few options it resets after the first.