### PR TITLE
Fixes bug causing manual calls to UiPopover.open() and related elements not to work.

### DIFF
--- a/src/UiPopover.vue
+++ b/src/UiPopover.vue
@@ -148,7 +148,9 @@ export default {
 
         open() {
             if (this.tip) {
-                this.tip.show();
+                this.$nextTick(() => {
+                    this.tip.show();
+                });
             }
         },
 


### PR DESCRIPTION
Due to tippy adding a global click listener as described here https://github.com/atomiks/tippyjs/issues/273, manual calls to the popovers open method do not work when the manual call is triggered by a click event itself.

This commit moves the request to tippy into the next DOM update cycle to bypass the problem.

Fixes #419.