### PR TITLE
🐛 Fix to stop showing the UiSelect dropdown on click when the select control is disabled

### DIFF
--- a/src/UiPopover.vue
+++ b/src/UiPopover.vue
@@ -46,6 +46,10 @@ export default {
             type: Boolean,
             default: false
         },
+        disabled: {
+            type: Boolean,
+            default: false,
+        },
         focusRedirector: Function,
         openOn: {
             type: String,
@@ -71,6 +75,16 @@ export default {
         return {
             returnFocus: true,
         };
+    },
+
+    watch: {
+        disabled(n) {
+            if (this.tip && true === n) {
+                this.tip.disable();
+            } else {
+                this.tip.enable();
+            }
+        }
     },
 
     mounted() {

--- a/src/UiSelect.vue
+++ b/src/UiSelect.vue
@@ -56,6 +56,7 @@
                     ref="dropdown"
 
                     :constrain-to-scroll-parent="false"
+                    :disabled="disabled"
 
                     @close="onClose"
                     @open="onOpen"


### PR DESCRIPTION
Fixes #424. This fix adds a 'disabled' prop to the popover element to allow toggling of the underlying tippy instances tooltip availability.