### PR TITLE
:key="index" => :key="JSON.stringify(suggestion)"

### DIFF
--- a/src/UiAutocomplete.vue
+++ b/src/UiAutocomplete.vue
@@ -59,7 +59,7 @@
                         ref="suggestions"
 
                         :highlighted="highlightedIndex === index"
-                        :key="index"
+                        :key="JSON.stringify(suggestion)"
                         :keys="keys"
                         :suggestion="suggestion"
                         :type="type"


### PR DESCRIPTION
The framework needs the keys to be stable for performant rerender. Index is inherently unstable.