### PR TITLE
UiModal: close on backdrop click only if backdrop also got `mousedown`

### DIFF
--- a/src/UiModal.vue
+++ b/src/UiModal.vue
@@ -179,7 +179,9 @@ export default {
             if (!this.dismissible) {
                 return;
             }
-            if(this.beforeClose && !this.beforeClose(this)) return;
+            if (this.beforeClose && this.beforeClose(this) === false) {
+                return;
+            }
 
             this.isOpen = false;
         },

--- a/src/UiModal.vue
+++ b/src/UiModal.vue
@@ -206,7 +206,8 @@ export default {
             } else {
                 this.redirectFocus();
             }
-            this.backdropMouseDown = false;
+
+            this.mouseDownSource = undefined;
         },
 
         onEsc() {

--- a/src/UiModal.vue
+++ b/src/UiModal.vue
@@ -197,7 +197,7 @@ export default {
         },
 
         onBackdropMouseDown() {
-            this.backdropMouseDown = true;
+            this.mouseDownSource = 'backdrop';
         },
 
         onBackdropMouseUp() {

--- a/src/UiModal.vue
+++ b/src/UiModal.vue
@@ -6,7 +6,8 @@
             :class="classes"
             :role="role"
 
-            @click.self="onBackdropClick"
+            @mousedown.self="onBackdropMouseDown"
+            @mouseup.self="onBackdropMouseUp"
 
             v-show="isOpen"
         >
@@ -16,7 +17,8 @@
                 :class="{ 'has-dummy-scrollbar': preventShift }"
                 :style="alignTopStyle"
 
-                @click.self="onBackdropClick"
+                @mousedown.self="onBackdropMouseDown"
+                @mouseup.self="onBackdropMouseUp"
             >
                 <ui-focus-container
                     class="ui-modal__container"
@@ -190,12 +192,17 @@ export default {
             }
         },
 
-        onBackdropClick() {
-            if (this.dismissOnBackdrop) {
+        onBackdropMouseDown() {
+            this.backdropMouseDown = true;
+        },
+
+        onBackdropMouseUp() {
+            if (this.dismissOnBackdrop && this.backdropMouseDown) {
                 this.close();
             } else {
                 this.redirectFocus();
             }
+            this.backdropMouseDown = false;
         },
 
         onEsc() {

--- a/src/UiModal.vue
+++ b/src/UiModal.vue
@@ -106,7 +106,8 @@ export default {
         dismissOn: {
             type: String,
             default: 'backdrop esc close-button'
-        }
+        },
+        beforeClose: Function,
     },
 
     data() {
@@ -178,6 +179,7 @@ export default {
             if (!this.dismissible) {
                 return;
             }
+            if(this.beforeClose && !this.beforeClose(this)) return;
 
             this.isOpen = false;
         },

--- a/src/UiModal.vue
+++ b/src/UiModal.vue
@@ -201,7 +201,7 @@ export default {
         },
 
         onBackdropMouseUp() {
-            if (this.dismissOnBackdrop && this.backdropMouseDown) {
+            if (this.dismissOnBackdrop && this.mouseDownSource === 'backdrop') {
                 this.close();
             } else {
                 this.redirectFocus();


### PR DESCRIPTION
… got the mousedown event

Currently, users selecting text within the modal and releasing the mouse outside the modal are surprised that the modal closes.