### PR TITLE
Add `autocapitalize` prop to UiTextbox

### DIFF
--- a/docs-src/pages/UiTextbox.vue
+++ b/docs-src/pages/UiTextbox.vue
@@ -166,6 +166,32 @@
 
                 v-model="textbox15"
             ></ui-textbox>
+
+            <h4 class="page__demo-title">Type: text, autocapitalize: none</h4>
+
+            <ui-textbox
+                help="Enter some (case-specific) machine-generated text, which should not be capitalized accidentally on touch-screen devices"
+                label="Content"
+                placeholder="Content to be entered"
+                type="text"
+
+                autocapitalize="none"
+
+                v-model.number="textbox16"
+            ></ui-textbox>
+
+            <h4 class="page__demo-title">Multi-line text, autocapitalize: none</h4>
+
+            <ui-textbox
+                help="Enter some (case-specific) machine-generated text, which should not be capitalized accidentally on touch-screen devices"
+                label="Content"
+                placeholder="Content to be entered"
+
+                :multi-line="true"
+                autocapitalize="none"
+
+                v-model.number="textbox17"
+            ></ui-textbox>
         </div>
 
         <h3 class="page__section-title">API</h3>
@@ -639,7 +665,9 @@ export default {
             textbox12: 0,
             textbox13: '',
             textbox14: '',
-            textbox15: 'My name is Jane Doe...'
+            textbox15: 'My name is Jane Doe...',
+            textbox16: '',
+            textbox17: ''
         };
     },
 

--- a/docs-src/pages/UiTextbox.vue
+++ b/docs-src/pages/UiTextbox.vue
@@ -295,6 +295,19 @@
                             </tr>
 
                             <tr>
+                                <td>autocapitalize</td>
+                                <td>String</td>
+                                <td></td>
+                                <td>
+                                    <p>The type of autocapitalize behaviour the browser should offer for the input. Most useful for touch-screen UI.</p>
+
+                                    <p>See the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize" target="_blank" rel="noopener">autocapitalize attribute docs</a> for more info.</p>
+
+                                    <p>Set to <code>"none"</code> to ensure that text input elements do not start using sentence casing.</p>
+                                </td>
+                            </tr>
+
+                            <tr>
                                 <td>autosize</td>
                                 <td>Boolean</td>
                                 <td><code>true</code></td>

--- a/src/UiTextbox.vue
+++ b/src/UiTextbox.vue
@@ -13,6 +13,7 @@
                     ref="input"
 
                     :autocomplete="autocomplete ? autocomplete : null"
+                    :autocapitalize="autocapitalize ? autocapitalize : null"
                     :disabled="disabled"
                     :max="maxValue"
                     :maxlength="enforceMaxlength ? maxlength : null"
@@ -44,6 +45,7 @@
                     ref="textarea"
 
                     :autocomplete="autocomplete ? autocomplete : null"
+                    :autocapitalize="autocapitalize ? autocapitalize : null"
                     :disabled="disabled"
                     :maxlength="enforceMaxlength ? maxlength : null"
                     :minlength="minlength"
@@ -132,6 +134,7 @@ export default {
             default: 2
         },
         autocomplete: String,
+        autocapitalize: String,
         autofocus: {
             type: Boolean,
             default: false


### PR DESCRIPTION
Fixes #500

**Update**: Now has documentation updates to showcase [autocapitalize attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize)

* [X] passes npm run lint
* [X] updates documentation
* [X] tested locally using `yarn dev` and opening `http://127.0.0.1:9000` 