### PR TITLE
Allow for checking out (but not pushing) `CRLF` on Windows

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,9 @@ module.exports = {
     rules: {
         indent: ['error', 4],
 
+        // Allow CRLF on Windows. Git should be used to ensure commits are LF only.
+        'linebreak-style': [2, "windows"],
+
         // Need PascalCase for components and kebab-case for everything else
         'unicorn/filename-case': ['off'],
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+[core]
+	autocrlf = input


### PR DESCRIPTION
Git on windows defaults to `CRLF` when checking out and then converting to `LF` when push upstream.

This should allow linux and mac users to continue to follow `LF`, but allow pass on windows hosts with `CRLF`

Fixes #502 