### PR TITLE
UiFileupload: also reset placeholder when clear is called

### DIFF
--- a/src/UiFileupload.vue
+++ b/src/UiFileupload.vue
@@ -173,6 +173,8 @@ export default {
         },
 
         clear() {
+            this.hasSelection = false;
+
             // Clear the file input by removing the element and re-rendering (via v-if)
             this.renderInput = false;
 


### PR DESCRIPTION
When calling `clear()` on `UIFileupload`, I expected the placeholder to be cleared as well.

Use case:
I want an upload button that
1. always displays "Upload", and not the name of the selected file
2. possible to select the same file twice in a row

The latter can be solved with `clear()` today, but it appears that the only way I can reset the placeholder today is by setting `this.$refs.upload.hasSelection = false`, but that's dirty and undocumented.

With this patch, I can call `clear()` in the `change` or `input` event handler, and both 1 and 2 are satisfied.