### PR TITLE
Fix UiSwitch thumb overlapping an open modal

### DIFF
--- a/src/UiSwitch.vue
+++ b/src/UiSwitch.vue
@@ -17,11 +17,11 @@
                 @focus="onFocus"
             >
 
+            <div class="ui-switch__track"></div>
+
             <div class="ui-switch__thumb">
                 <div class="ui-switch__focus-ring"></div>
             </div>
-
-            <div class="ui-switch__track"></div>
         </div>
 
         <div class="ui-switch__label-text" v-if="label || $slots.default">
@@ -213,7 +213,6 @@ $ui-switch-focus-ring-size  : $ui-switch-thumb-size * 2.1 !default;
     transition-property: background-color, transform;
     transition-timing-function: ease;
     width: $ui-switch-thumb-size;
-    z-index: 1;
 }
 
 .ui-switch__focus-ring {


### PR DESCRIPTION
### Current Behavior (switch bleeds into model, even with modal `z-index: 99999`)

<img width="1323" alt="Screen Shot 2020-10-12 at 1 43 55 PM" src="https://user-images.githubusercontent.com/17692058/95775934-f460c400-0c88-11eb-99ce-5081e6d7414a.png">
<img width="1326" alt="Screen Shot 2020-10-12 at 1 44 14 PM" src="https://user-images.githubusercontent.com/17692058/95775942-f88ce180-0c88-11eb-824e-6cb3dc1046b1.png">

<br>
<br>
<br>

### Behavior After `.ui-switch__thumb { z-index: unset }`

<img width="1327" alt="Screen Shot 2020-10-12 at 1 45 34 PM" src="https://user-images.githubusercontent.com/17692058/95776039-27a35300-0c89-11eb-8f36-4f2f6861f858.png">

<br>
<br>
<br>

### This PR Behavior (change element order instead of using z-index)

<img width="1328" alt="Screen Shot 2020-10-12 at 1 50 15 PM" src="https://user-images.githubusercontent.com/17692058/95776262-9680ac00-0c89-11eb-94e8-c9d82aaffc1f.png">
<img width="1327" alt="Screen Shot 2020-10-12 at 1 50 33 PM" src="https://user-images.githubusercontent.com/17692058/95776274-9bddf680-0c89-11eb-9f48-73f92667aad7.png">


