### PR TITLE
Fix zero value being treated as falsy in UiTextbox value length

### DIFF
--- a/src/UiTextbox.vue
+++ b/src/UiTextbox.vue
@@ -236,7 +236,10 @@ export default {
         },
 
         valueLength() {
-            return this.value ? this.value.length : 0;
+            if (this.value == null) {
+                return 0;
+            }
+            return (`${this.value}`).length;
         },
 
         hasFeedback() {

--- a/src/UiTextbox.vue
+++ b/src/UiTextbox.vue
@@ -236,10 +236,7 @@ export default {
         },
 
         valueLength() {
-            if (this.value == null) {
-                return 0;
-            }
-            return (`${this.value}`).length;
+            return this.value === null ? 0 : String(this.value).length;
         },
 
         hasFeedback() {


### PR DESCRIPTION
when the value is `0` (the number) it has a length of 1 char, but the `this.value ? this.value.length : 0` fails to pick that up

ex: 
![Screen Shot 2020-12-13 at 1 36 01 PM](https://user-images.githubusercontent.com/17692058/102021913-fc041e00-3d48-11eb-8f5e-54df95fb0cc6.png)

![Screen Shot 2020-12-13 at 1 35 54 PM](https://user-images.githubusercontent.com/17692058/102021923-058d8600-3d49-11eb-8ef3-10359f8a07a9.png)
