### PR TITLE
Make popover support shadow DOM

### DIFF
--- a/src/UiPopover.vue
+++ b/src/UiPopover.vue
@@ -113,12 +113,14 @@ export default {
                 return;
             }
 
+            const body = this.triggerEl.getRootNode() === document ? document.body : this.triggerEl.getRootNode();
+
             const options = {
                 animateFill: false,
                 // Use 'fade' when animation is 'none', as 'none' it's not a valid Tippy.js option.
                 // The effect of no transition is achieved by `duration: 0` below.
                 animation: this.animation === 'none' ? 'fade' : this.animation,
-                appendTo: this.appendToBody ? document.body : this.triggerEl.parentElement,
+                appendTo: this.appendToBody ? body : this.triggerEl.parentElement,
                 arrow: false,
                 content: this.$el,
                 delay: [0, 0],

--- a/src/UiPopover.vue
+++ b/src/UiPopover.vue
@@ -113,6 +113,7 @@ export default {
                 return;
             }
 
+            // When the element is placed inside a shadow DOM node we need to attach the popover to its root instead of the document root
             const body = this.triggerEl.getRootNode() === document ? document.body : this.triggerEl.getRootNode();
 
             const options = {


### PR DESCRIPTION
When using Keen-UI components in the shadow DOM, we need the popovers to be appended only to the root node of the Shadow DOM.