### PR TITLE
Hide UiCollapsible content overflow only during animation

### DIFF
--- a/src/UiCollapsible.vue
+++ b/src/UiCollapsible.vue
@@ -217,8 +217,11 @@ $ui-collapsible-header-background-hover     : $md-grey-300 !default;
 
 .ui-collapsible__body-wrapper {
     max-height: 0;
-    overflow: hidden;
     transition: max-height 0.3s ease;
+
+    &.v-enter-active, &.v-leave-active {
+        overflow: hidden;
+    }
 }
 
 .ui-collapsible__body {

--- a/src/UiCollapsible.vue
+++ b/src/UiCollapsible.vue
@@ -219,7 +219,8 @@ $ui-collapsible-header-background-hover     : $md-grey-300 !default;
     max-height: 0;
     transition: max-height 0.3s ease;
 
-    &.v-enter-active, &.v-leave-active {
+    &.v-enter-active,
+    &.v-leave-active {
         overflow: hidden;
     }
 }


### PR DESCRIPTION
Sometimes we need to have elements that are out of the collapsible scope (we have a color picker in our case) and it is hidden by the collapsible. But because we only need overflow hidden while animating we can assign it to Vue's animation classes.