### PR TITLE
Add options to control closure of the popover.

### DIFF
--- a/docs-src/pages/UiPopover.vue
+++ b/docs-src/pages/UiPopover.vue
@@ -200,6 +200,27 @@
                             </tr>
 
                             <tr>
+                                <td>closeOnEsc</td>
+                                <td>Boolean</td>
+                                <td><code>true</code></td>
+                                <td>
+                                    <p>Whether or not the popover should be closed when the escape key is pressed
+                                        while it's open.</p>
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <td>closeOnExternalClick</td>
+                                <td>Boolean</td>
+                                <td><code>true</code></td>
+                                <td>
+                                    <p>Whether or not the popover should be closed when the user click outside of it
+                                        while it's open.</p>
+                                    <p>Set to <code>false</code> to keep the popover open when the user clicks outside of the popover.</p>
+                                </td>
+                            </tr>
+
+                            <tr>
                                 <td>constrainToScrollParent</td>
                                 <td>Boolean</td>
                                 <td><code>true</code></td>

--- a/src/UiPopover.vue
+++ b/src/UiPopover.vue
@@ -38,6 +38,14 @@ export default {
             type: Boolean,
             default: true
         },
+        closeOnExternalClick: {
+            type: Boolean,
+            default: true
+        },
+        closeOnEsc: {
+            type: Boolean,
+            default: true
+        },
         constrainToScrollParent: {
             type: Boolean,
             default: true
@@ -127,7 +135,7 @@ export default {
                 delay: [0, 0],
                 distance: 0,
                 duration: this.animation === 'none' ? 0 : [250, 200],
-                hideOnClick: true,
+                hideOnClick: this.closeOnExternalClick,
                 ignoreAttributes: true,
                 interactive: true,
                 lazy: true,
@@ -247,13 +255,17 @@ export default {
 
             // Add event listeners in the next tick, otherwise they're triggered immediately
             setTimeout(() => {
-                this.removeExternalClickListener = events.on('click', document, e => {
-                    this.closeOnExternal(e, { returnFocus: false });
-                });
+                if (this.closeOnExternalClick) {
+                    this.removeExternalClickListener = events.on('click', document, e => {
+                        this.closeOnExternal(e, { returnFocus: false });
+                    });
+                }
 
-                this.removeEscListener = events.onKeydown(27, document, () => {
-                    this.close({ returnFocus: true });
-                });
+                if (this.closeOnEsc) {
+                    this.removeEscListener = events.onKeydown(27, document, () => {
+                        this.close({ returnFocus: true });
+                    });
+                }
 
                 if (this.closeOnScroll) {
                     this.removeScrollListener = events.on('scroll', document, e => {


### PR DESCRIPTION
Adds 'close-on-esc' and 'close-on-external-click' props to the UiPopover component in a non-breaking manor.

These props give the ability to fully control a popovers display state. This allows us to force parent popovers to stay open when nested popovers (which are appended to the body) receive click events.

Addresses #535.