### PR TITLE
Fix UISlider marker from being dependent on the global line-height.

### DIFF
--- a/src/UiSlider.vue
+++ b/src/UiSlider.vue
@@ -543,7 +543,7 @@ $ui-slider-marker-size                      : rem(36px);
     left: 0;
     position: absolute;
     text-align: center;
-    top: rem(4px);
+    line-height: 2.3;
     transition: color $ui-track-focus-ring-transition-duration ease;
     width: $ui-slider-marker-size;
 }


### PR DESCRIPTION
The UiSlider's marker text is now showing correctly in the docs because the .page class has `line-height: 1.6`. When used in a project with different line heights the marker text position is not aligned well vertically. This fix addresses that.