### PR TITLE
UiTab: Add icon prop

### DIFF
--- a/docs-src/pages/UiTabs.vue
+++ b/docs-src/pages/UiTabs.vue
@@ -74,10 +74,6 @@
                         </div>
                     </template>
 
-                    <template #icon>
-                        <ui-icon :icon="tab.icon"></ui-icon>
-                    </template>
-
                     <p>{{ tab.title }}</p>
                 </ui-tab>
             </ui-tabs>
@@ -90,11 +86,10 @@
                     :id="tab.id"
                     :key="tab.id"
                     :title="tab.title"
+                    :icon="tab.icon"
+
                     v-for="tab in controlTabs"
                 >
-                    <template #icon>
-                        <ui-icon :icon="tab.icon"></ui-icon>
-                    </template>
                     <div>{{ tab.title }}</div>
                 </ui-tab>
             </ui-tabs>
@@ -329,6 +324,16 @@
                                 <td>String</td>
                                 <td></td>
                                 <td>The tab title (text only).</td>
+                            </tr>
+
+                            <tr>
+                                <td>icon</td>
+                                <td>String</td>
+                                <td></td>
+                                <td>
+                                    <p>The tab icon. Can be any of the <a href="https://design.google.com/icons/" target="_blank" rel="noopener">Material Icons</a>.</p>
+                                    <p>You can set a custom or SVG icon using the <code>icon</code> slot.</p>
+                                </td>
                             </tr>
 
                             <tr>

--- a/src/UiTab.vue
+++ b/src/UiTab.vue
@@ -29,6 +29,7 @@ export default {
             }
         },
         title: String,
+        icon: String,
         selected: {
             type: Boolean,
             default: false

--- a/src/UiTabHeaderItem.vue
+++ b/src/UiTabHeaderItem.vue
@@ -11,7 +11,8 @@
     >
         <slot>
             <div class="ui-tab-header-item__icon" v-if="hasIcon">
-                <slot name="icon"></slot>
+                <slot name="icon" v-if="$slots.icon"></slot>
+                <ui-icon :icon="icon" v-else-if="icon"/>
             </div>
 
             <div class="ui-tab-header-item__text" v-if="hasText">{{ title }}</div>
@@ -40,6 +41,7 @@ export default {
             default: 'text' // 'text', 'icon', or 'icon-and-text'
         },
         title: String,
+        icon: String,
         active: {
             type: Boolean,
             default: false

--- a/src/UiTabs.vue
+++ b/src/UiTabs.vue
@@ -11,6 +11,7 @@
                     :id="tab.id"
                     :key="tab.id"
                     :title="tab.title"
+                    :icon="tab.icon"
                     :type="type"
 
                     @click="onTabClick(tab, $event)"
@@ -20,7 +21,7 @@
                     v-for="tab in tabs"
                 >
                     <render :nodes="tab.$slots.header()" v-if="tab.$slots.header"></render>
-                    <template v-if="!tab.$slots.header && hasIcon && Boolean(tab.$slots.icon)" #icon>
+                    <template v-if="!tab.$slots.header && tab.$slots.icon && hasIcon" #icon>
                         <render :nodes="tab.$slots.icon()"></render>
                     </template>
                 </ui-tab-header-item>


### PR DESCRIPTION
The reason for this is that in Vue 3 we are required to use <template> for slots and it creates a lot of boilerplate code for the UiTab component when it can be easily achieved with a simple icon prop. Let me know what you think!