### PR TITLE
Make blocking event listeners passive

### DIFF
--- a/src/UiPopover.vue
+++ b/src/UiPopover.vue
@@ -272,7 +272,7 @@ export default {
                 if (this.closeOnScroll) {
                     this.removeScrollListener = events.on('scroll', document, e => {
                         this.closeOnExternal(e, { returnFocus: true });
-                    }, { passive: true });
+                    });
                 }
             }, 0);
         },

--- a/src/UiPopover.vue
+++ b/src/UiPopover.vue
@@ -272,7 +272,7 @@ export default {
                 if (this.closeOnScroll) {
                     this.removeScrollListener = events.on('scroll', document, e => {
                         this.closeOnExternal(e, { returnFocus: true });
-                    });
+                    }, { passive: true });
                 }
             }, 0);
         },

--- a/src/UiRippleInk.vue
+++ b/src/UiRippleInk.vue
@@ -142,7 +142,7 @@ export default {
                 return;
             }
 
-            this.triggerEl.addEventListener('touchstart', handleTouchStart);
+            this.triggerEl.addEventListener('touchstart', handleTouchStart, { passive: true });
             this.triggerEl.addEventListener('mousedown', handleMouseDown);
         },
 

--- a/src/UiSlider.vue
+++ b/src/UiSlider.vue
@@ -36,7 +36,7 @@
             class="ui-slider__track"
             ref="track"
             @mousedown="onDragStart"
-            @touchstart="onDragStart"
+            @touchstart.passive="onDragStart"
         >
             <div class="ui-slider__track-background">
                 <template v-if="snapToSteps">
@@ -290,8 +290,8 @@ export default {
             this.isDragging = true;
             this.dragUpdate(e);
 
-            document.addEventListener('touchmove', this.onDragMove);
-            document.addEventListener('mousemove', this.onDragMove);
+            document.addEventListener('touchmove', this.onDragMove, { passive: true });
+            document.addEventListener('mousemove', this.onDragMove, { passive: true });
 
             this.$emit('dragstart', this.localValue, e);
         },

--- a/src/UiSlider.vue
+++ b/src/UiSlider.vue
@@ -291,7 +291,7 @@ export default {
             this.dragUpdate(e);
 
             document.addEventListener('touchmove', this.onDragMove, { passive: true });
-            document.addEventListener('mousemove', this.onDragMove, { passive: true });
+            document.addEventListener('mousemove', this.onDragMove);
 
             this.$emit('dragstart', this.localValue, e);
         },


### PR DESCRIPTION
We need to make the event listeners for blocking events passive so that they don't impact performance. Also, browsers throw lots of warnings because of them.
Reference: https://web.dev/uses-passive-event-listeners/