### PR TITLE
UiCheckbox, UiRadio, UiSelect, UiSwitch: emit normalized value on create only if different from current value

### DIFF
--- a/src/UiCheckbox.vue
+++ b/src/UiCheckbox.vue
@@ -94,7 +94,10 @@ export default {
     },
 
     created() {
-        this.$emit('update:modelValue', this.isChecked ? this.trueValue : this.falseValue);
+        const value = this.isChecked ? this.trueValue : this.falseValue;
+        if (this.modelValue !== value) {
+            this.$emit('update:modelValue', value);
+        }
     },
 
     methods: {

--- a/src/UiRadio.vue
+++ b/src/UiRadio.vue
@@ -88,7 +88,7 @@ export default {
     },
 
     created() {
-        if (this.checked) {
+        if (this.checked && !this.isChecked) {
             this.$emit('update:modelValue', this.trueValue);
         }
     },

--- a/src/UiRadioGroup.vue
+++ b/src/UiRadioGroup.vue
@@ -102,8 +102,7 @@ export default {
     data() {
         return {
             isActive: false,
-            initialValue: this.modelValue,
-            selectedOptionValue: this.modelValue
+            initialValue: this.modelValue
         };
     },
 
@@ -129,17 +128,16 @@ export default {
 
         showHelp() {
             return Boolean(this.help) || Boolean(this.$slots.help);
-        }
-    },
-
-    watch: {
-        selectedOptionValue() {
-            this.$emit('update:modelValue', this.selectedOptionValue);
-            this.$emit('change', this.selectedOptionValue);
         },
 
-        modelValue() {
-            this.selectedOptionValue = this.modelValue;
+        selectedOptionValue: {
+            get() {
+                return this.modelValue;
+            },
+            set(value) {
+                this.$emit('update:modelValue', value);
+                this.$emit('change', value);
+            }
         }
     },
 

--- a/src/UiSelect.vue
+++ b/src/UiSelect.vue
@@ -399,7 +399,9 @@ export default {
     },
 
     created() {
-        if ((this.multiple && !Array.isArray(this.modelValue)) || (!this.modelValue && this.modelValue !== '')) {
+        const invalidMultipleValue = this.multiple && !Array.isArray(this.modelValue);
+        const invalidEmptyValue = !this.modelValue && this.modelValue !== '';
+        if (invalidMultipleValue || invalidEmptyValue) {
             this.$emit('update:modelValue', this.emptyValue);
             this.initialValue = JSON.stringify(this.emptyValue);
         }

--- a/src/UiSelect.vue
+++ b/src/UiSelect.vue
@@ -372,6 +372,10 @@ export default {
             }
 
             return this.modelValue[this.keys.value] || this.modelValue;
+        },
+
+        emptyValue() {
+            return this.multiple ? [] : '';
         }
     },
 
@@ -395,15 +399,14 @@ export default {
     },
 
     created() {
-        if (!this.modelValue || this.modelValue === '') {
-            this.setValue(null);
+        if ((this.multiple && !Array.isArray(this.modelValue)) || (!this.modelValue && this.modelValue !== '')) {
+            this.$emit('update:modelValue', this.emptyValue);
+            this.initialValue = JSON.stringify(this.emptyValue);
         }
     },
 
     methods: {
         setValue(value) {
-            value = value ? value : this.multiple ? [] : '';
-
             this.$emit('update:modelValue', value);
             this.$emit('change', value);
         },
@@ -500,7 +503,7 @@ export default {
         },
 
         clearSelection() {
-            this.setValue(null);
+            this.setValue(this.emptyValue);
         },
 
         clearQuery() {

--- a/src/UiSwitch.vue
+++ b/src/UiSwitch.vue
@@ -100,7 +100,10 @@ export default {
     },
 
     created() {
-        this.$emit('update:modelValue', this.isChecked ? this.trueValue : this.falseValue);
+        const value = this.isChecked ? this.trueValue : this.falseValue;
+        if (this.modelValue !== value) {
+            this.$emit('update:modelValue', value);
+        }
     },
 
     methods: {


### PR DESCRIPTION
Some components were generating initial emits. It makes sense when the value is normalized, but sometimes it would just resend the initial value which is not really necessary. I have added some checks to prevent that.

Reason for this: For some components we have wrappers and it is really important to have consistency at the library level so that we know that events are only emitted when really needed.

Sorry for the amount of PRs lately. We've been using a branch with all these changes and I think it would be great to have them in the following release! Let me know what you think.