### PR TITLE
UiSlider: Make marker text independent of the global line-height

### DIFF
--- a/src/UiSlider.vue
+++ b/src/UiSlider.vue
@@ -546,7 +546,7 @@ $ui-slider-marker-size                      : rem(36px);
     left: 0;
     position: absolute;
     text-align: center;
-    top: rem(4px);
+    line-height: 2.3;
     transition: color $ui-track-focus-ring-transition-duration ease;
     width: $ui-slider-marker-size;
 }

--- a/src/UiSlider.vue
+++ b/src/UiSlider.vue
@@ -389,7 +389,8 @@ $ui-track-focus-ring-transition-duration    : 0.2s !default;
 $ui-track-focus-ring-color                  : rgba($ui-track-thumb-fill-color, 0.38) !default;
 
 // Marker
-$ui-slider-marker-size                      : rem(36px);
+$ui-slider-marker-size                      : rem(36px) !default;
+$ui-slider-marker-font-size                 : rem(13px) !default;
 
 .ui-slider {
     align-items: center;
@@ -540,13 +541,13 @@ $ui-slider-marker-size                      : rem(36px);
 }
 
 .ui-slider__marker-text {
-    color: $ui-track-thumb-fill-color;;
-    font-size: rem(13px);
+    color: $ui-track-thumb-fill-color;
+    font-size: $ui-slider-marker-font-size;
     font-weight: 600;
     left: 0;
     position: absolute;
     text-align: center;
-    line-height: 2.3;
+    line-height: $ui-slider-marker-size * 0.8; // 0.8 is the aspect ratio of the width of the svg marker against its height
     transition: color $ui-track-focus-ring-transition-duration ease;
     width: $ui-slider-marker-size;
 }


### PR DESCRIPTION
The UiSlider's marker text is now showing correctly in the docs because the .page class has line-height: 1.6. When used in a project with different line heights the marker text position is not aligned well vertically. This fix addresses that.

There was an issue with the previous PR so I created a new one.

The general issue here is that the "drop" SVG icon has not the same width and height. By calculating the ratio between the height and the width we can make sure that the text will always be at the center of the "visual" circle. Let me know what you think of this solution. It looks a bit dirty but seems to be the best one.

I have also extracted the font size to a variable so it can be configured, it also helps to test if the marker text is positioned correctly visually. This will be handy when having larger text, but I can reverse this if you think it's too much.