### PR TITLE
Add variables for the bold and semibold font weights

### DIFF
--- a/src/UiButton.vue
+++ b/src/UiButton.vue
@@ -221,7 +221,7 @@ export default {
     display: inline-flex;
     font-family: $font-stack;
     font-size: $ui-button-font-size;
-    font-weight: 600;
+    font-weight: $ui-button-font-weight;
     height: $ui-button-height;
     justify-content: center;
     letter-spacing: 0.02em;

--- a/src/UiCalendarControls.vue
+++ b/src/UiCalendarControls.vue
@@ -155,7 +155,7 @@ export default {
 
 .ui-calendar-controls__month-and-year {
     font-size: rem(15px);
-    font-weight: 600;
+    font-weight: $font-weight--bold;
 }
 
 // ================================================

--- a/src/UiCalendarControls.vue
+++ b/src/UiCalendarControls.vue
@@ -155,7 +155,7 @@ export default {
 
 .ui-calendar-controls__month-and-year {
     font-size: rem(15px);
-    font-weight: $font-weight--bold;
+    font-weight: $font-weight--semibold;
 }
 
 // ================================================

--- a/src/UiCalendarMonth.vue
+++ b/src/UiCalendarMonth.vue
@@ -133,7 +133,7 @@ export default {
     th {
         color: $secondary-text-color;
         font-size: rem(14px);
-        font-weight: 600;
+        font-weight: $font-weight--bold;
         height: $ui-calendar-month-header-height;
         text-align: center;
         text-transform: uppercase;

--- a/src/UiCalendarMonth.vue
+++ b/src/UiCalendarMonth.vue
@@ -133,7 +133,7 @@ export default {
     th {
         color: $secondary-text-color;
         font-size: rem(14px);
-        font-weight: $font-weight--bold;
+        font-weight: $font-weight--semibold;
         height: $ui-calendar-month-header-height;
         text-align: center;
         text-transform: uppercase;

--- a/src/UiCalendarWeek.vue
+++ b/src/UiCalendarWeek.vue
@@ -174,7 +174,7 @@ export default {
     }
 
     &.is-today {
-        font-weight: bold;
+        font-weight: $font-weight--bold;
     }
 
     &.is-disabled {

--- a/src/UiDatepickerCalendar.vue
+++ b/src/UiDatepickerCalendar.vue
@@ -307,7 +307,7 @@ $ui-datepicker-calendar-padding : rem(8px) !default;
 
 .ui-datepicker-calendar__header-year {
     font-size: rem(15px);
-    font-weight: $font-weight--bold;
+    font-weight: $font-weight--semibold;
     margin-bottom: rem(8px);
 }
 
@@ -352,7 +352,7 @@ $ui-datepicker-calendar-padding : rem(8px) !default;
 
     &.is-selected {
         font-size: rem(24px);
-        font-weight: $font-weight--bold;
+        font-weight: $font-weight--semibold;
         height: rem(40px);
     }
 }

--- a/src/UiDatepickerCalendar.vue
+++ b/src/UiDatepickerCalendar.vue
@@ -307,7 +307,7 @@ $ui-datepicker-calendar-padding : rem(8px) !default;
 
 .ui-datepicker-calendar__header-year {
     font-size: rem(15px);
-    font-weight: 600;
+    font-weight: $font-weight--bold;
     margin-bottom: rem(8px);
 }
 
@@ -352,7 +352,7 @@ $ui-datepicker-calendar-padding : rem(8px) !default;
 
     &.is-selected {
         font-size: rem(24px);
-        font-weight: 600;
+        font-weight: $font-weight--bold;
         height: rem(40px);
     }
 }

--- a/src/UiFileupload.vue
+++ b/src/UiFileupload.vue
@@ -204,7 +204,7 @@ export default {
     display: inline-flex;
     font-family: $font-stack;
     font-size: $ui-button-font-size;
-    font-weight: 600;
+    font-weight: $ui-button-font-weight;
     height: $ui-button-height;
     justify-content: center;
     letter-spacing: 0.02em;

--- a/src/UiSelectOption.vue
+++ b/src/UiSelectOption.vue
@@ -106,7 +106,7 @@ $ui-select-option-checkbox-color: rgba(black, 0.38) !default;
     &.is-selected {
         background-color: rgba(black, 0.05);
         color: $brand-primary-color;
-        font-weight: $font-weight--bold;
+        font-weight: $font-weight--semibold;
 
         .ui-select-option__checkbox {
             color: $brand-primary-color;

--- a/src/UiSelectOption.vue
+++ b/src/UiSelectOption.vue
@@ -106,7 +106,7 @@ $ui-select-option-checkbox-color: rgba(black, 0.38) !default;
     &.is-selected {
         background-color: rgba(black, 0.05);
         color: $brand-primary-color;
-        font-weight: 600;
+        font-weight: $font-weight--bold;
 
         .ui-select-option__checkbox {
             color: $brand-primary-color;

--- a/src/UiSlider.vue
+++ b/src/UiSlider.vue
@@ -542,7 +542,7 @@ $ui-slider-marker-size                      : rem(36px);
 .ui-slider__marker-text {
     color: $ui-track-thumb-fill-color;;
     font-size: rem(13px);
-    font-weight: $font-weight--bold;
+    font-weight: $font-weight--semibold;
     left: 0;
     position: absolute;
     text-align: center;

--- a/src/UiSlider.vue
+++ b/src/UiSlider.vue
@@ -542,7 +542,7 @@ $ui-slider-marker-size                      : rem(36px);
 .ui-slider__marker-text {
     color: $ui-track-thumb-fill-color;;
     font-size: rem(13px);
-    font-weight: 600;
+    font-weight: $font-weight--bold;
     left: 0;
     position: absolute;
     text-align: center;

--- a/src/UiTabHeaderItem.vue
+++ b/src/UiTabHeaderItem.vue
@@ -115,7 +115,7 @@ export default {
 .ui-tab-header-item__text {
     @include text-truncation;
     font-size: rem(15px);
-    font-weight: $font-weight--bold;
+    font-weight: $font-weight--semibold;
 }
 
 .ui-tab-header-item__icon {

--- a/src/UiTabHeaderItem.vue
+++ b/src/UiTabHeaderItem.vue
@@ -115,7 +115,7 @@ export default {
 .ui-tab-header-item__text {
     @include text-truncation;
     font-size: rem(15px);
-    font-weight: 600;
+    font-weight: $font-weight--bold;
 }
 
 .ui-tab-header-item__icon {

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -3,7 +3,8 @@
 
 // The UI font stack
 $font-stack             : -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
-$font-weight--bold       : 600 !default;
+$font-weight--semibold  : 600 !default;
+$font-weight--bold      : 700 !default;
 
 // Base font size
 $base-font-size         : 100% !default; // typically 16px in most browsers
@@ -92,7 +93,7 @@ $ui-button-font-size--large         : rem(16px) !default;
 $ui-button-height                   : rem(36px) !default;
 $ui-button-height--small            : rem(32px) !default;
 $ui-button-height--large            : rem(48px) !default;
-$ui-button-font-weight              : $font-weight--bold !default;
+$ui-button-font-weight              : $font-weight--semibold !default;
 
 // ================================================
 // Dropdowns (UiAutocomplete, UiPopover, UiMenu, UiSelect)

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -3,6 +3,7 @@
 
 // The UI font stack
 $font-stack             : -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
+$font-weight--bold       : 600 !default;
 
 // Base font size
 $base-font-size         : 100% !default; // typically 16px in most browsers
@@ -91,6 +92,7 @@ $ui-button-font-size--large         : rem(16px) !default;
 $ui-button-height                   : rem(36px) !default;
 $ui-button-height--small            : rem(32px) !default;
 $ui-button-height--large            : rem(48px) !default;
+$ui-button-font-weight              : $font-weight--bold !default;
 
 // ================================================
 // Dropdowns (UiAutocomplete, UiPopover, UiMenu, UiSelect)


### PR DESCRIPTION
In some projects, we have different font sets and sometimes they don't include the 600 font weight. By making this change we make it flexible to configure this using a global SASS variable.

Note: This is an updated PR as the previous one was broken due to fork recreation.