### PR TITLE
Fix in transition of first snackbar shown

### DIFF
--- a/src/UiSnackbar.vue
+++ b/src/UiSnackbar.vue
@@ -1,5 +1,5 @@
 <template>
-    <transition :name="transitionName" @after-enter="onEnter" @after-leave="onLeave">
+    <transition :name="transitionName" @after-enter="onEnter" @after-leave="onLeave" appear>
         <div class="ui-snackbar">
             <div class="ui-snackbar__message">
                 <slot>{{ message }}</slot>


### PR DESCRIPTION
The snackbar transition was broken after moving to Vue 3, this was caused by the difference in how the transition was handled on element insertion (rather than appearing with v-show).

Another solution would be to wrap `queue[0].show = true` in a $nextTick, so that the vnode is first inserted and only afterward shown but I think this solution is much more elegant.