### PR TITLE
UiAlert enhancement: Change 'dismissible' to 'persist' (#468)

### DIFF
--- a/docs-src/pages/UiAlert.vue
+++ b/docs-src/pages/UiAlert.vue
@@ -49,10 +49,10 @@
                 Animations for this alert are disabled.
             </ui-alert>
 
-            <ui-alert :dismissible="false">This alert is not dismissible.</ui-alert>
+            <ui-alert :persist="true">This alert is not dismissible.</ui-alert>
 
-            <ui-alert :dismissible="false" remove-icon>
-                This alert has no icon is not dismissible.
+            <ui-alert :persist="true" remove-icon>
+                This alert has no icon and is not dismissible.
             </ui-alert>
 
             <ui-button @click="resetAlerts">Reset Alerts</ui-button>
@@ -105,13 +105,13 @@
                             </tr>
 
                             <tr>
-                                <td>dismissible</td>
+                                <td>persist</td>
                                 <td>Boolean</td>
-                                <td><code>true</code></td>
+                                <td><code>false</code></td>
                                 <td>
                                     <p>Whether or not the alert shows a dismiss button.</p>
                                     <p>You should listen for the <code>dismiss</code> event and hide the alert.</p>
-                                    <p>Set to <code>false</code> to remove the dismiss button.</p>
+                                    <p>Set to <code>true</code> to remove the dismiss button.</p>
                                 </td>
                             </tr>
                         </tbody>

--- a/src/UiAlert.vue
+++ b/src/UiAlert.vue
@@ -43,7 +43,7 @@
         </div>
 
         <div class="ui-alert__dismiss-button">
-          <ui-close-button v-if="dismissible" size="small" @click="dismissAlert"></ui-close-button>
+          <ui-close-button v-if="!persist" size="small" @click="dismissAlert"></ui-close-button>
         </div>
       </div>
     </div>
@@ -75,9 +75,9 @@ export default {
       type: Boolean,
       default: false,
     },
-    dismissible: {
+    persist: {
       type: Boolean,
-      default: true,
+      default: false,
     },
   },
 


### PR DESCRIPTION
This PR brings one of the enhancements suggested in #468, which is changing the `dismissible` prop to `persist` for the `UiAlert` component.